### PR TITLE
Add top-level set!

### DIFF
--- a/docs/scratch.md
+++ b/docs/scratch.md
@@ -1,0 +1,23 @@
+# Scratch documents
+
+This file contains lose notes used during development. They will eventually be assembled into proper documentation.
+
+## Basic approach to build the language
+
+Read and parse the input text to produce an AST.
+Perform macro expansion to obtain an AST with only Scheme core forms.
+Apply CPS transformation to the core forms AST, resulting in a CPS-based IR.
+Perform optimization passes on the CPS-based IR (details to be determined).
+Generate VM instructions, compiling each closure into a chunk.
+Emit the bytecode and any additional information required by the VM to execute the code.
+
+```mermaid
+graph LR
+A[Input Text] --> B[AST with Macros]
+B --> C[Core Forms AST]
+C --> D[CPS-based IR]
+D --> E[Optimization Passes]
+E --> F[VM Instructions]
+F --> G[Bytecode and Additional Info]
+```
+

--- a/system/test/helpers.go
+++ b/system/test/helpers.go
@@ -1,0 +1,5 @@
+package system_test
+
+func CompileModule(code string) {
+	// use the compiler to compile the code to a module
+}

--- a/system/test/jit_test.go
+++ b/system/test/jit_test.go
@@ -1,0 +1,4 @@
+package system_test
+
+// Test the entire compile -> vm chain in a JIT fashion
+// That means we compile sourcecode to compilation units which we run directly with the VM

--- a/vm/internal/bytecode/chunk.go
+++ b/vm/internal/bytecode/chunk.go
@@ -1,0 +1,41 @@
+package bytecode
+
+import (
+	"fmt"
+
+	"github.com/certainty/go-braces/vm/internal/language/value"
+)
+
+type Address = uint32
+type ConstAddress = uint32
+
+type Chunk struct {
+	Instructions      []Instruction      // The sequence of instructions to execute
+	Constants         []value.Value      // The constant values used by the instructions
+	IntrospectionInfo *IntrospectionInfo // Auxiliary information for introspection
+	DebugInfo         *DebugInfo         // Auxiliary information for debugging
+}
+
+func (c *Chunk) InstructionAt(address Address) (*Instruction, error) {
+	if address >= uint32(len(c.Instructions)) {
+		return nil, fmt.Errorf("no instruction at address %d", address)
+	}
+
+	return &c.Instructions[address], nil
+}
+
+func (c *Chunk) ConstantAt(address ConstAddress) (*value.Value, error) {
+	if address >= uint32(len(c.Constants)) {
+		return nil, fmt.Errorf("no constant at address %d", address)
+	}
+
+	return &c.Constants[address], nil
+}
+
+func (c *Chunk) IntrospectionInfoAt(address Address) (*SourceInformation, error) {
+	return c.IntrospectionInfo.SourceInformationAt(address)
+}
+
+func (c *Chunk) Size() uint32 {
+	return uint32(len(c.Instructions))
+}

--- a/vm/internal/bytecode/chunk_builder.go
+++ b/vm/internal/bytecode/chunk_builder.go
@@ -1,0 +1,50 @@
+package bytecode
+
+import "github.com/certainty/go-braces/vm/internal/language/value"
+
+type ChunkBuilder struct {
+	instructions      []Instruction
+	constants         map[value.Value]ConstAddress
+	constIndex        uint32
+	sourceInformation []SourceInformation
+}
+
+func NewChunkBuilder() *ChunkBuilder {
+	return &ChunkBuilder{
+		instructions:      make([]Instruction, 0),
+		constants:         make(map[value.Value]ConstAddress),
+		constIndex:        0,
+		sourceInformation: make([]SourceInformation, 0),
+	}
+}
+
+func (cb *ChunkBuilder) AddInstruction(instruction Instruction, source SourceInformation) Address {
+	cb.instructions = append(cb.instructions, instruction)
+	cb.sourceInformation = append(cb.sourceInformation, source)
+	return Address(len(cb.instructions) - 1)
+}
+
+func (cb *ChunkBuilder) AddConstant(constant value.Value) ConstAddress {
+	if address, ok := cb.constants[constant]; ok {
+		return address
+	} else {
+		cb.constants[constant] = cb.constIndex
+		cb.constIndex++
+		return cb.constIndex - 1
+	}
+}
+
+func (cb *ChunkBuilder) Build() *Chunk {
+	constants := make([]value.Value, len(cb.constants))
+
+	for value, address := range cb.constants {
+		constants[address] = value
+	}
+
+	return &Chunk{
+		Instructions:      cb.instructions,
+		Constants:         constants,
+		IntrospectionInfo: &IntrospectionInfo{sourceInformation: cb.sourceInformation},
+		DebugInfo:         nil,
+	}
+}

--- a/vm/internal/bytecode/chunk_builder_test.go
+++ b/vm/internal/bytecode/chunk_builder_test.go
@@ -1,0 +1,41 @@
+package bytecode_test
+
+import (
+	"testing"
+
+	"github.com/certainty/go-braces/vm/internal/bytecode"
+	"github.com/certainty/go-braces/vm/internal/language/value"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkBuilderCanBuildChunkWithSingleConstant(t *testing.T) {
+	valueFactory := value.NewFactory()
+	chunkBuilder := bytecode.NewChunkBuilder()
+	chunkBuilder.AddConstant(valueFactory.Bool(true))
+
+	chunk := chunkBuilder.Build()
+
+	assert.Equal(t, 1, len(chunk.Constants), "Chunk should have one constant")
+}
+
+func TestChunkBuilderCanBuildChunkWithMultipleConstants(t *testing.T) {
+	valueFactory := value.NewFactory()
+	chunkBuilder := bytecode.NewChunkBuilder()
+	chunkBuilder.AddConstant(valueFactory.Bool(true))
+	chunkBuilder.AddConstant(valueFactory.Bool(false))
+
+	chunk := chunkBuilder.Build()
+
+	assert.Equal(t, 2, len(chunk.Constants), "Chunk should have three constants")
+}
+
+func TestChunkBuilderDeduplicatesConstants(t *testing.T) {
+	valueFactory := value.NewFactory()
+	chunkBuilder := bytecode.NewChunkBuilder()
+	chunkBuilder.AddConstant(valueFactory.Bool(true))
+	chunkBuilder.AddConstant(valueFactory.Bool(true))
+
+	chunk := chunkBuilder.Build()
+
+	assert.Equal(t, 1, len(chunk.Constants), "Chunk should have one constant")
+}

--- a/vm/internal/bytecode/chunk_builder_test.go
+++ b/vm/internal/bytecode/chunk_builder_test.go
@@ -1,11 +1,10 @@
 package bytecode_test
 
 import (
-	"testing"
-
 	"github.com/certainty/go-braces/vm/internal/bytecode"
 	"github.com/certainty/go-braces/vm/internal/language/value"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestChunkBuilderCanBuildChunkWithSingleConstant(t *testing.T) {
@@ -38,4 +37,36 @@ func TestChunkBuilderDeduplicatesConstants(t *testing.T) {
 	chunk := chunkBuilder.Build()
 
 	assert.Equal(t, 1, len(chunk.Constants), "Chunk should have one constant")
+}
+
+func TestChunkBuilderCanBuildChunkWithSingleInstruction(t *testing.T) {
+	chunkBuilder := bytecode.NewChunkBuilder()
+	address := chunkBuilder.AddInstruction(bytecode.Unspecified(), bytecode.NewSourceInformation(10, 3))
+
+	chunk := chunkBuilder.Build()
+
+	sourceInfo, err := chunk.IntrospectionInfo.SourceInformationAt(address)
+
+	assert.Nil(t, err, "Chunk should have an instruction at the given address")
+	assert.Equal(t, uint32(10), sourceInfo.Span.Line, "Chunk should return correct span for instruction")
+	assert.Equal(t, uint32(3), sourceInfo.Span.Column, "Chunk should return correct span for instruction")
+}
+
+func TestChunkBuilderCanBuildChunkWithMultipleInstructions(t *testing.T) {
+	chunkBuilder := bytecode.NewChunkBuilder()
+	address1 := chunkBuilder.AddInstruction(bytecode.Unspecified(), bytecode.NewSourceInformation(10, 3))
+	address2 := chunkBuilder.AddInstruction(bytecode.Nil(), bytecode.NewSourceInformation(10, 3))
+
+	chunk := chunkBuilder.Build()
+
+	sourceInfo, err := chunk.IntrospectionInfo.SourceInformationAt(address1)
+
+	assert.Nil(t, err, "Chunk should have an instruction at the given address")
+	assert.Equal(t, uint32(10), sourceInfo.Span.Line, "Chunk should return correct span for instruction")
+	assert.Equal(t, uint32(3), sourceInfo.Span.Column, "Chunk should return correct span for instruction")
+
+	sourceInfo, err = chunk.IntrospectionInfo.SourceInformationAt(address2)
+	assert.Nil(t, err, "Chunk should have an instruction at the given address")
+	assert.Equal(t, uint32(10), sourceInfo.Span.Line, "Chunk should return correct span for instruction")
+	assert.Equal(t, uint32(3), sourceInfo.Span.Column, "Chunk should return correct span for instruction")
 }

--- a/vm/internal/bytecode/chunk_test.go
+++ b/vm/internal/bytecode/chunk_test.go
@@ -1,0 +1,1 @@
+package bytecode_test

--- a/vm/internal/bytecode/debug.go
+++ b/vm/internal/bytecode/debug.go
@@ -1,0 +1,4 @@
+package bytecode
+
+type DebugInfo struct {
+}

--- a/vm/internal/bytecode/instruction.go
+++ b/vm/internal/bytecode/instruction.go
@@ -1,0 +1,48 @@
+package bytecode
+
+type OpCode uint8
+
+const (
+	OpPush OpCode = iota
+	OpPop
+	OpNop
+	OpConst
+	OpSet
+	OpTrue
+	OpFalse
+	OpNil
+	OpUnspecified
+)
+
+type Instruction struct {
+	OpCode OpCode
+	Args   []interface{}
+}
+
+func NewInstruction(opCode OpCode, args ...interface{}) Instruction {
+	return Instruction{OpCode: opCode, Args: args}
+}
+
+func Set() Instruction {
+	return NewInstruction(OpSet)
+}
+
+func True() Instruction {
+	return NewInstruction(OpTrue)
+}
+
+func False() Instruction {
+	return NewInstruction(OpFalse)
+}
+
+func Unspecified() Instruction {
+	return NewInstruction(OpUnspecified)
+}
+
+func Nil() Instruction {
+	return NewInstruction(OpNil)
+}
+
+func Const(address ConstAddress) Instruction {
+	return NewInstruction(OpConst, address)
+}

--- a/vm/internal/bytecode/introspection.go
+++ b/vm/internal/bytecode/introspection.go
@@ -1,0 +1,24 @@
+package bytecode
+
+import "fmt"
+
+type SourceSpan struct {
+	line   uint32
+	column uint32
+}
+
+type SourceInformation struct {
+	Span SourceSpan
+	// we will store additional information in the future
+}
+
+type IntrospectionInfo struct {
+	sourceInformation []SourceInformation
+}
+
+func (ii IntrospectionInfo) SourceInformationAt(address Address) (*SourceInformation, error) {
+	if address >= uint32(len(ii.sourceInformation)) {
+		return nil, fmt.Errorf("no source information for instruction at address %d", address)
+	}
+	return &ii.sourceInformation[address], nil
+}

--- a/vm/internal/bytecode/introspection.go
+++ b/vm/internal/bytecode/introspection.go
@@ -3,13 +3,23 @@ package bytecode
 import "fmt"
 
 type SourceSpan struct {
-	line   uint32
-	column uint32
+	Line   uint32
+	Column uint32
 }
 
 type SourceInformation struct {
 	Span SourceSpan
 	// we will store additional information in the future
+}
+
+func NewSourceInformation(line, column uint32) SourceInformation {
+	span := SourceSpan{
+		Line:   line,
+		Column: column,
+	}
+	return SourceInformation{
+		Span: span,
+	}
 }
 
 type IntrospectionInfo struct {

--- a/vm/internal/bytecode/module.go
+++ b/vm/internal/bytecode/module.go
@@ -1,0 +1,6 @@
+package bytecode
+
+type Module struct {
+	chunk Chunk
+	// there is more to come
+}

--- a/vm/internal/language/value/factory.go
+++ b/vm/internal/language/value/factory.go
@@ -1,0 +1,34 @@
+package value
+
+// Use a factory to create scheme values
+type Factory struct {
+	true        Value
+	false       Value
+	nil         Value
+	unspecified Value
+}
+
+func NewFactory() *Factory {
+	return &Factory{
+		true:        true,
+		false:       false,
+		nil:         Nil,
+		unspecified: Unspecified,
+	}
+}
+
+func (f *Factory) Bool(v bool) *Value {
+	if v {
+		return &f.true
+	} else {
+		return &f.false
+	}
+}
+
+func (f *Factory) Nil() *Value {
+	return &f.nil
+}
+
+func (f *Factory) Unspecified() *Value {
+	return &f.unspecified
+}

--- a/vm/internal/language/value/value.go
+++ b/vm/internal/language/value/value.go
@@ -1,0 +1,10 @@
+package value
+
+type Value interface{}
+
+type BoolValue bool
+type UndefinedValue uint8
+type NilValue uint8
+
+const Nil = 0
+const Unspecified = 1


### PR DESCRIPTION
This adds support for the set! command at the top-level. It might look like an odd choice, but we have to start somewhere, and it already and early on confronts us with decisions around the scheme object model and how variables are represented. 
Remember scheme uses mutable cells. 